### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ py-social
 [![Build Status](https://travis-ci.org/paulocheque/py-social.png?branch=master)](https://travis-ci.org/paulocheque/py-social)
 [![Docs Status](https://readthedocs.org/projects/py-social/badge/?version=latest)](http://py-social.readthedocs.org/en/latest/index.html)
 [![Coverage Status](https://coveralls.io/repos/paulocheque/py-social/badge.png?branch=master)](https://coveralls.io/r/paulocheque/py-social?branch=master)
-[![PyPi version](https://pypip.in/v/py-social/badge.png)](https://crate.io/packages/py-social/)
-[![PyPi downloads](https://pypip.in/d/py-social/badge.png)](https://crate.io/packages/py-social/)
+[![PyPi version](https://img.shields.io/pypi/v/py-social.svg)](https://crate.io/packages/py-social/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/py-social.svg)](https://crate.io/packages/py-social/)
 
 **Latest version: 0.0.1 (2014/09)**
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20py-social))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `py-social`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.